### PR TITLE
XIVY-11350 Improve version handling in Axon Ivy Designer

### DIFF
--- a/src/app/domain/market/MavenProductInfo.php
+++ b/src/app/domain/market/MavenProductInfo.php
@@ -147,6 +147,7 @@ class MavenProductInfo
       $designerVersion = (new Version($designerVersion))->getMinorVersion();
     }
     $versions = array_filter($versions, fn(string $v) => str_starts_with($v, $designerVersion) || (!str_contains($v, '-SNAPSHOT') && !str_contains($v, '-m')));
+    $versions = MavenArtifact::filterSnapshotsBetweenReleasedVersions($versions);
     return array_values($versions);
   }
 

--- a/src/app/domain/market/MavenProductInfo.php
+++ b/src/app/domain/market/MavenProductInfo.php
@@ -157,10 +157,21 @@ class MavenProductInfo
       return reset($versions);
     }
     if (Version::isValidVersionNumber($designerVersion)) {
-      $designerVersion = (new Version($designerVersion))->getMinorVersion();
+
+      // favor exact match
       foreach ($versions as $v) {
-        if (str_starts_with($v, $designerVersion)) {
+        if ($v == $designerVersion) {
           return $v;
+        }
+      }
+
+      // use version before exact match. because the version in the market defines the minimum version of the product
+      $designerMinorVersion = (new Version($designerVersion))->getMinorVersion();
+      foreach ($versions as $v) {
+        if (version_compare($v, $designerVersion) == -1) {
+          if (str_starts_with($v, $designerMinorVersion)) {
+            return $v;
+          }
         }
       }
     }

--- a/src/app/domain/market/ProductDescription.php
+++ b/src/app/domain/market/ProductDescription.php
@@ -4,6 +4,7 @@ namespace app\domain\market;
 use League\CommonMark\MarkdownConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
@@ -71,6 +72,7 @@ class ProductDescription
 
     $environment = new Environment();
     $environment->addExtension(new CommonMarkCoreExtension());
+    $environment->addExtension(new GithubFlavoredMarkdownExtension());
     $environment->addRenderer(Image::class, new MakeImageUrlsAbsolute($assetBaseUrl));
     $converter = new MarkdownConverter($environment);
     return $converter->convert($markdownContent);

--- a/src/app/domain/maven/MavenArtifact.php
+++ b/src/app/domain/maven/MavenArtifact.php
@@ -3,6 +3,7 @@
 namespace app\domain\maven;
 
 use app\domain\market\Product;
+use app\domain\Version;
 
 class MavenArtifact
 {
@@ -140,6 +141,34 @@ class MavenArtifact
     return $this->versionCache;
   }
   
+  public static function filterSnapshotsBetweenReleasedVersions(array $versions): array
+  {
+    return array_values(array_filter($versions, fn($version) => self::filterBetweenSnapshots($versions, $version)));
+  }
+
+  private static function filterBetweenSnapshots(array $versions, string $version): bool
+  {
+    if (str_ends_with($version, '-SNAPSHOT')) {
+      $bugFixVersion = str_replace('-SNAPSHOT', '', $version);
+      $minorVersion = (new Version($bugFixVersion))->getMinorNumber();
+      foreach ($versions as $v) {
+        if ((new Version($v))->getMinorNumber() == $minorVersion) {
+          if (version_compare($bugFixVersion, $v) == -1) {
+            return false;
+          }
+        }
+      }
+    }
+    /*
+    if (str_contains($v, '-m')) {
+      $relasedVersion = substr($v, 0, strpos($v, "-m"));
+      if (in_array($relasedVersion, $versions)) {
+        return false;
+      }
+    }*/
+    return true;
+  }
+
   public static function filterSnapshotsWhichAreRealesed(array $versions): array
   {
     return array_values(array_filter($versions, fn($version) => self::filterReleasedSnapshots($versions, $version)));

--- a/src/app/domain/maven/MavenArtifact.php
+++ b/src/app/domain/maven/MavenArtifact.php
@@ -159,13 +159,6 @@ class MavenArtifact
         }
       }
     }
-    /*
-    if (str_contains($v, '-m')) {
-      $relasedVersion = substr($v, 0, strpos($v, "-m"));
-      if (in_array($relasedVersion, $versions)) {
-        return false;
-      }
-    }*/
     return true;
   }
 

--- a/test/domain/maven/MavenArtifactTest.php
+++ b/test/domain/maven/MavenArtifactTest.php
@@ -24,6 +24,21 @@ class MavenArtifactTest extends TestCase
     Assert::assertEquals('9.1.0', $result[2]);
   }
   
+  public function testFilterSnapshotsBetweenReleasedVersions()
+  {
+    $versions = [
+      '10.0.0', '9.2.2-SNAPSHOT', '9.2.1', '9.2.0', '9.2.0-SNAPSHOT', '9.1.0'
+    ];
+    $result = MavenArtifact::filterSnapshotsBetweenReleasedVersions($versions);
+    
+    Assert::assertCount(5, $result);
+    Assert::assertEquals('10.0.0', $result[0]);
+    Assert::assertEquals('9.2.2-SNAPSHOT', $result[1]);
+    Assert::assertEquals('9.2.1', $result[2]);
+    Assert::assertEquals('9.2.0', $result[3]);
+    Assert::assertEquals('9.1.0', $result[4]);
+  }
+
   public function testGetMavenArtifact()
   {
     (new ProductMavenArtifactDownloader())->download(Market::getProductByKey('workflow-demo'), "10.0.0");


### PR DESCRIPTION
- XIVY-11350 Always prefer exact match, fallback to the next earlier version for version auto selection
- XIVY-11350 Show only last snapshot version of a minor train
